### PR TITLE
Add --depth param to clone without commit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a step-by-step guide that takes you straight from downloading this boil
 **1. Clone this repo:**
 
 ```sh
-git clone git@github.com:developit/preact-boilerplate.git my-app
+git clone --depth 1 git@github.com:developit/preact-boilerplate.git my-app
 cd my-app
 ```
 
@@ -32,10 +32,10 @@ cd my-app
 **2. Make it your own:**
 
 ```sh
-rm -rf .git && git init && npm init
+npm init
 ```
 
-> :information_source: This re-initializes the repo and sets up your NPM project.
+> :information_source: This sets up your NPM project.
 
 
 **3. Install the dependencies:**

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ cd my-app
 **2. Make it your own:**
 
 ```sh
-npm init
+rm -rf .git && git init && npm init
 ```
 
-> :information_source: This sets up your NPM project.
+> :information_source: This re-initializes the repo and sets up your NPM project.
 
 
 **3. Install the dependencies:**


### PR DESCRIPTION
The param `--depth 1` in [git clone](https://git-scm.com/docs/git-clone) make a clone without commit history.