### PR TITLE
Adds netlify deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ npm run build
 > You can now deploy the contents of the `build` directory to production!
 >
 > **[Surge.sh](https://surge.sh) Example:** `surge ./build -d my-app.surge.sh`
+> 
+> **[Netlify](https://www.netlify.com/docs/cli/) Example:** `netlify deploy`
+>
+> [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/developit/preact-boilerplate)
 
 
 **5. Start local production server with `superstatic`:**

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
   command = "npm run build"
   publish = "build"
+	branch = "master"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   command = "npm run build"
   publish = "build"
-	branch = "master"
+  branch = "master"


### PR DESCRIPTION
Hi, My apologies for being forward but I am a fan of what you have done and excited that this boiler exists. We are using Preact for a client project at Netlify and will most likely use this boiler for a tutorial on our blog soon. 

I opened this PR to add a Netlify example and one click deploy button. The netlify.toml file just populates the build command bundle output location.

test out the button here:

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/preact-boilerplate)

Let me know if you have any questions. Also if you have interest we offer a free plan at Netlify for all open source projects, check out the details [here](https://netlify.com/open-source) if you are interested in using it for Preact examples or even https://preactjs.com/.

Cheers 🎉 