### PR TITLE
Use absolute path for favicons

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -20,7 +20,7 @@
 	<meta name="format-detection" content="telephone=no">
 	<meta name="theme-color" content="#673ab8">
 	<link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/apple-touch-icon.png">
-	<link rel="icon" type="image/png" href="./assets/icons/favicon-32x32.png" sizes="32x32">
+	<link rel="icon" type="image/png" href="/assets/icons/favicon-32x32.png" sizes="32x32">
 	<link rel="icon" type="image/png" href="/assets/icons/favicon-16x16.png" sizes="16x16">
 	<link rel="manifest" href="./manifest.json">
 </head>


### PR DESCRIPTION
The existing path for the 32x32 favicon was a relative path, which results in a 404 error whenever the current page/route was more than one level deep.