### PR TITLE
Gzip App Bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-register": "^6.24.0",
     "babel-runtime": "^6.11.6",
     "chai": "^3.5.0",
+    "compression-webpack-plugin": "^0.4.0",
     "copy-webpack-plugin": "^4.0.1",
     "core-js": "^2.4.1",
     "cross-env": "^4.0.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,5 +1,6 @@
 import webpack from 'webpack';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
+import CompressionWebpackPlugin from 'compression-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import autoprefixer from 'autoprefixer';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
@@ -162,6 +163,13 @@ module.exports = {
 				cascade: true,
 				drop_console: true
 			}
+		}),
+		new CompressionWebpackPlugin({
+				asset: "[path].gz[query]",
+				algorithm: "gzip",
+				test: /\.(js|html)$/,
+				threshold: 10240,
+				minRatio: 0.8
 		}),
 
 		// strip out babel-helper invariant checks


### PR DESCRIPTION
Right now, when you run `npm run build`, it only minifies and bundles the files. In my current app, I get this:

<img width="854" alt="screen shot 2017-06-01 at 11 39 38 pm" src="https://cloud.githubusercontent.com/assets/2946769/26705020/3dfc02c2-472b-11e7-855c-e10d9cbb6ebe.png">

With this PR, you can now optimize your app bundle further by gzipping the files. Now your app bundle size will reduce greatly just like mine did like so:

<img width="794" alt="screen shot 2017-06-02 at 12 27 47 am" src="https://cloud.githubusercontent.com/assets/2946769/26705044/633500f2-472b-11e7-8fab-902836377208.png">

`bundle.js.gz - 39.3kb`

Whoop! Whoop!

@developit please review!