### PR TITLE
Fix npm task to exclude webpack command line production flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --progress",
     "start": "serve build -s -c 1",
     "prestart": "npm run build",
-    "build": "cross-env NODE_ENV=production webpack -p --progress",
+    "build": "cross-env NODE_ENV=production webpack --progress",
     "prebuild": "mkdirp build && ncp src/assets build/assets",
     "test": "npm run -s lint && jest --coverage",
     "test:watch": "npm run -s test -- --watch",


### PR DESCRIPTION
The `-p` flag along with `UglifyJSPlugin` breaks the npm task. As per this comment https://github.com/webpack/webpack/issues/1385#issuecomment-160553651, it'd be great to remotve the cli flag `-p` and we should be back to good.