### PR TITLE
Fixed to open on the defined homepage instead **undefined** route. 

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -201,6 +201,7 @@ module.exports = {
 		contentBase: './src',
 		historyApiFallback: true,
 		open: true,
+		openPage: '',
 		proxy: {
 			// OPTIONAL: proxy configuration:
 			// '/optional-prefix/**': { // path pattern to rewrite


### PR DESCRIPTION
As a quick fix, you can add `openPage: ''` and this will work as expected. This problem does not occur when using the CLI with --open flag, But when set to file `webpack.config.js` it will open in an undefined route, for example: `http://localhost:3000/undefined`