### PR TITLE
Add CSS minification

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -56,7 +56,7 @@ module.exports = {
 					use: [
 						{
 							loader: 'css-loader',
-							options: { modules: true, sourceMap: CSS_MAPS, importLoaders: 1 }
+							options: { modules: true, sourceMap: CSS_MAPS, importLoaders: 1, minimize: true }
 						},
 						{
 							loader: `postcss-loader`,
@@ -82,7 +82,7 @@ module.exports = {
 					use: [
 						{
 							loader: 'css-loader',
-							options: { sourceMap: CSS_MAPS, importLoaders: 1 }
+							options: { sourceMap: CSS_MAPS, importLoaders: 1, minimize: true }
 						},
 						{
 							loader: `postcss-loader`,


### PR DESCRIPTION
> The end result of a minification step is that the resulting code will behave the same as the original file, but some parts will be altered to reduce the size as much as possible. 

The **css-loader** minimizes the css if specified by the module system. By default: `minimize: false`.

https://github.com/webpack-contrib/css-loader#options
