### PR TITLE
Duplicated CSS Configuration in Webpack config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -75,32 +75,6 @@ module.exports = {
 				})
 			},
 			{
-				test: /\.(less|css)$/,
-				exclude: [path.resolve(__dirname, 'src/components')],
-				use: ExtractTextPlugin.extract({
-					fallback: 'style-loader',
-					use: [
-						{
-							loader: 'css-loader',
-							options: { sourceMap: CSS_MAPS, importLoaders: 1, minimize: true }
-						},
-						{
-							loader: `postcss-loader`,
-							options: {
-								sourceMap: CSS_MAPS,
-								plugins: () => {
-									autoprefixer({ browsers: [ 'last 2 versions' ] });
-								}
-							}
-						},
-						{
-							loader: 'less-loader',
-							options: { sourceMap: CSS_MAPS }
-						}
-					]
-				})
-			},
-			{
 				test: /\.json$/,
 				use: 'json-loader'
 			},


### PR DESCRIPTION
Seems the only difference is `modules: true` in `css-loader` configuration.